### PR TITLE
removed duplicated ifdef

### DIFF
--- a/keyboards/keychron/q1/rev_0101/rev_0101.c
+++ b/keyboards/keychron/q1/rev_0101/rev_0101.c
@@ -17,7 +17,6 @@
 #include "quantum.h"
 
 #ifdef RGB_MATRIX_ENABLE
-#ifdef RGB_MATRIX_ENABLE
 const is31_led __flash g_is31_leds[DRIVER_LED_TOTAL] = {
 /* Refer to IS31 manual for these locations
  *   driver


### PR DESCRIPTION
There was a duplicated line in keyboards/keychron/q1/rev_0101/rev_0101.c that caused compilation to fail with a "unterminated #ifdef" error.