### PR TITLE
Enable support for edit RGB lighting in VIA.

### DIFF
--- a/keyboards/keychron/q1/config.h
+++ b/keyboards/keychron/q1/config.h
@@ -48,6 +48,11 @@
 /* Disable RGB lighting when PC is in suspend */
 #define RGB_DISABLE_WHEN_USB_SUSPENDED
 
+/* Allow VIA to edit lighting */
+#ifdef VIA_ENABLE
+#define VIA_QMK_RGBLIGHT_ENABLE
+#endif
+
 // RGB Matrix Animation modes. Explicitly enabled
 // For full list of effects, see:
 // https://docs.qmk.fm/#/feature_rgb_matrix?id=rgb-matrix-effects


### PR DESCRIPTION
The updated design file at https://git.io/JyE0K includes only the
enabled RGB_MATRIX modes.

## Description

Define **VIA_QMK_RGBLIGHT_ENABLE** if **VIA_ENABLE** is defined.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation