### PR TITLE
[Q1] add caps lock indicator

### DIFF
--- a/keyboards/keychron/q1/q1.c
+++ b/keyboards/keychron/q1/q1.c
@@ -17,6 +17,8 @@
 #include "q1.h"
 #include "test.c"
 
+#ifdef DIP_SWITCH_ENABLE
+
 bool dip_switch_update_kb(uint8_t index, bool active) {
     if (!dip_switch_update_user(index, active)) { return false;}
     if (index == 0) {
@@ -24,3 +26,24 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
     }
     return true;
 }
+
+#endif
+
+
+#if defined(RGB_MATRIX_ENABLE) && !defined(DISABLE_CAPS_LOCK_LIGHT)
+
+#define CAPS_LOCK_LED_INDEX 45
+#define CAPS_LOCK_BRIGHTNESS 0xFF
+#ifdef RGB_MATRIX_MAXIMUM_BRIGHTNESS
+    #undef CAPS_LOCK_BRIGHTNESS
+    #define CAPS_LOCK_BRIGHTNESS RGB_MATRIX_MAXIMUM_BRIGHTNESS
+#endif
+
+__attribute__((weak))
+void rgb_matrix_indicators_user(void) {
+    if (host_keyboard_led_state().caps_lock) {
+        rgb_matrix_set_color(CAPS_LOCK_LED_INDEX, CAPS_LOCK_BRIGHTNESS, CAPS_LOCK_BRIGHTNESS, CAPS_LOCK_BRIGHTNESS);  // white
+    }
+}
+
+#endif

--- a/keyboards/keychron/q1/q1.c
+++ b/keyboards/keychron/q1/q1.c
@@ -30,9 +30,8 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
 #endif
 
 
-#if defined(RGB_MATRIX_ENABLE) && !defined(DISABLE_CAPS_LOCK_LIGHT)
+#if defined(RGB_MATRIX_ENABLE) && defined(CAPS_LOCK_LED_INDEX)
 
-#define CAPS_LOCK_LED_INDEX 45
 #define CAPS_LOCK_BRIGHTNESS 0xFF
 #ifdef RGB_MATRIX_MAXIMUM_BRIGHTNESS
     #undef CAPS_LOCK_BRIGHTNESS

--- a/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/config.h
+++ b/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/config.h
@@ -59,3 +59,6 @@
 
 /* Specifies the number of pulses the encoder registers between each detent */
 #define ENCODER_RESOLUTION 4
+
+/* Enable caps-lock LED */
+#define CAPS_LOCK_LED_INDEX 44


### PR DESCRIPTION
## Description

Create weak function to allow caps-lock ON states to show as white light under the caps-lock key.

`__attribute__((weak))` is used to allow keymap creators to override this.