### PR TITLE
Unblock process_record_user for certain keys

### DIFF
--- a/keyboards/keychron/factory/major/test.c
+++ b/keyboards/keychron/factory/major/test.c
@@ -60,6 +60,9 @@ uint8_t factory_reset_count = 0;
 bool report_os_sw_state = false;
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+    if (!process_record_user(keycode, record)) {
+        return false;
+    }
     switch (keycode) {
         case MO(MAC_FN):
         case MO(WIN_FN):

--- a/keyboards/keychron/factory/major/test.c
+++ b/keyboards/keychron/factory/major/test.c
@@ -123,8 +123,6 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 timer_3s_buffer = 0;
             }
             return true;
-        default:
-            return process_record_user(keycode, record);
     }
 }
 

--- a/keyboards/keychron/factory/major/test.c
+++ b/keyboards/keychron/factory/major/test.c
@@ -123,6 +123,8 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 timer_3s_buffer = 0;
             }
             return true;
+        default:
+            return true;
     }
 }
 


### PR DESCRIPTION
process_record_user should be called for all keys and if it returns true then process_record_kb will continue processing. Otherwise users will be unable to access those keys in their custom keymaps. As things stand the keyboard will silently ignore any processing of J,Z,RIGHT,HOME,FN keys for all keychron keyboards.
