### PR TITLE
bug fix: un-break keyboard_post_init_user() in all Keychron keyboards

### DIFF
--- a/keyboards/keychron/q1/q1_ansi_atmega32u4_ec11/q1_ansi_atmega32u4_ec11.c
+++ b/keyboards/keychron/q1/q1_ansi_atmega32u4_ec11/q1_ansi_atmega32u4_ec11.c
@@ -179,6 +179,9 @@ void keyboard_post_init_kb(void) {
     PCMSK0 |= (1 << 7);
     PCICR |= (1 << PCIE0);
     sei();
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 ISR(PCINT0_vect) {

--- a/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/q1_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/q1_ansi_stm32l432_ec11.c
@@ -186,6 +186,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #   endif

--- a/keyboards/keychron/q1/q1_iso_atmega32u4_ec11/q1_iso_atmega32u4_ec11.c
+++ b/keyboards/keychron/q1/q1_iso_atmega32u4_ec11/q1_iso_atmega32u4_ec11.c
@@ -178,6 +178,9 @@ void keyboard_post_init_kb(void) {
     PCMSK0 |= (1 << 7);
     PCICR |= (1 << PCIE0);
     sei();
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 ISR(PCINT0_vect) {

--- a/keyboards/keychron/q1/q1_iso_stm32l432_ec11/q1_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/q1/q1_iso_stm32l432_ec11/q1_iso_stm32l432_ec11.c
@@ -187,6 +187,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #   endif

--- a/keyboards/keychron/q1/q1_jis_stm32l432_ec11/q1_jis_stm32l432_ec11.c
+++ b/keyboards/keychron/q1/q1_jis_stm32l432_ec11/q1_jis_stm32l432_ec11.c
@@ -190,6 +190,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #   endif

--- a/keyboards/keychron/q10/q10_ansi_stm32l432_ec11/q10_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q10/q10_ansi_stm32l432_ec11/q10_ansi_stm32l432_ec11.c
@@ -187,6 +187,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // ENCODER_ENABLE

--- a/keyboards/keychron/q10/q10_iso_stm32l432_ec11/q10_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/q10/q10_iso_stm32l432_ec11/q10_iso_stm32l432_ec11.c
@@ -188,6 +188,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // ENCODER_ENABLE

--- a/keyboards/keychron/q2/q2_ansi_stm32l432_ec11/q2_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q2/q2_ansi_stm32l432_ec11/q2_ansi_stm32l432_ec11.c
@@ -159,6 +159,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif

--- a/keyboards/keychron/q2/q2_iso_stm32l432_ec11/q2_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/q2/q2_iso_stm32l432_ec11/q2_iso_stm32l432_ec11.c
@@ -160,6 +160,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif

--- a/keyboards/keychron/q3/q3_ansi_stm32l432_ec11/q3_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q3/q3_ansi_stm32l432_ec11/q3_ansi_stm32l432_ec11.c
@@ -183,6 +183,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/q3/q3_iso_stm32l432_ec11/q3_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/q3/q3_iso_stm32l432_ec11/q3_iso_stm32l432_ec11.c
@@ -183,6 +183,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/q3/q3_jis_stm32l432_ec11/q3_jis_stm32l432_ec11.c
+++ b/keyboards/keychron/q3/q3_jis_stm32l432_ec11/q3_jis_stm32l432_ec11.c
@@ -187,6 +187,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/q5/q5_ansi_stm32l432_ec11/q5_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q5/q5_ansi_stm32l432_ec11/q5_ansi_stm32l432_ec11.c
@@ -192,6 +192,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/q5/q5_iso_stm32l432_ec11/q5_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/q5/q5_iso_stm32l432_ec11/q5_iso_stm32l432_ec11.c
@@ -191,6 +191,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/q6/q6_ansi_stm32l432_ec11/q6_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q6/q6_ansi_stm32l432_ec11/q6_ansi_stm32l432_ec11.c
@@ -202,6 +202,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif

--- a/keyboards/keychron/q6/q6_iso_stm32l432_ec11/q6_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/q6/q6_iso_stm32l432_ec11/q6_iso_stm32l432_ec11.c
@@ -201,6 +201,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif

--- a/keyboards/keychron/q65/q65_ansi_stm32l432_ec11/q65_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q65/q65_ansi_stm32l432_ec11/q65_ansi_stm32l432_ec11.c
@@ -164,6 +164,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif

--- a/keyboards/keychron/q8/q8_ansi_stm32l432_ec11/q8_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q8/q8_ansi_stm32l432_ec11/q8_ansi_stm32l432_ec11.c
@@ -161,6 +161,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/q8/q8_iso_stm32l432_ec11/q8_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/q8/q8_iso_stm32l432_ec11/q8_iso_stm32l432_ec11.c
@@ -161,6 +161,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/q9/q9_ansi_stm32l432_ec11/q9_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/q9/q9_ansi_stm32l432_ec11/q9_ansi_stm32l432_ec11.c
@@ -137,6 +137,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 #    endif
 #endif

--- a/keyboards/keychron/q9/q9_iso_stm32l432_ec11/q9_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/q9/q9_iso_stm32l432_ec11/q9_iso_stm32l432_ec11.c
@@ -138,6 +138,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 #    endif
 #endif

--- a/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/v1_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/v1_ansi_stm32l432_ec11.c
@@ -177,8 +177,7 @@ bool encoder_update_kb(uint8_t index, bool clockwise) {
         palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
         palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
 
-        // allow user keymaps to do custom post_init too
-        // (like loading user eeprom data)
+        // allow user keymaps to do custom post_init
         keyboard_post_init_user();
     }
 

--- a/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/v1_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/v1_ansi_stm32l432_ec11.c
@@ -176,6 +176,10 @@ bool encoder_update_kb(uint8_t index, bool clockwise) {
         palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
         palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
         palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+        // allow user keymaps to do custom post_init too
+        // (like loading user eeprom data)
+        keyboard_post_init_user();
     }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/v1/v1_iso_stm32l432_ec11/v1_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/v1/v1_iso_stm32l432_ec11/v1_iso_stm32l432_ec11.c
@@ -180,6 +180,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/v1/v1_jis_stm32l432_ec11/v1_jis_stm32l432_ec11.c
+++ b/keyboards/keychron/v1/v1_jis_stm32l432_ec11/v1_jis_stm32l432_ec11.c
@@ -181,6 +181,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/v2/v2_ansi_stm32l432_ec11/v2_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/v2/v2_ansi_stm32l432_ec11/v2_ansi_stm32l432_ec11.c
@@ -158,6 +158,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 #    endif // PAL_USE_CALLBACKS
 #endif     // ENCODER_ENABLE

--- a/keyboards/keychron/v2/v2_iso_stm32l432_ec11/v2_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/v2/v2_iso_stm32l432_ec11/v2_iso_stm32l432_ec11.c
@@ -159,6 +159,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/v3/v3_ansi_stm32l432_ec11/v3_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/v3/v3_ansi_stm32l432_ec11/v3_ansi_stm32l432_ec11.c
@@ -183,6 +183,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/v3/v3_iso_stm32l432_ec11/v3_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/v3/v3_iso_stm32l432_ec11/v3_iso_stm32l432_ec11.c
@@ -183,6 +183,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/v5/v5_ansi_stm32l432_ec11/v5_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/v5/v5_ansi_stm32l432_ec11/v5_ansi_stm32l432_ec11.c
@@ -192,6 +192,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/v5/v5_iso_stm32l432_ec11/v5_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/v5/v5_iso_stm32l432_ec11/v5_iso_stm32l432_ec11.c
@@ -191,6 +191,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif // PAL_USE_CALLBACKS

--- a/keyboards/keychron/v6/v6_ansi_stm32l432_ec11/v6_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/v6/v6_ansi_stm32l432_ec11/v6_ansi_stm32l432_ec11.c
@@ -201,6 +201,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #    endif

--- a/keyboards/keychron/v8/v8_ansi_stm32l432_ec11/v8_ansi_stm32l432_ec11.c
+++ b/keyboards/keychron/v8/v8_ansi_stm32l432_ec11/v8_ansi_stm32l432_ec11.c
@@ -159,6 +159,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 
 #endif

--- a/keyboards/keychron/v8/v8_iso_stm32l432_ec11/v8_iso_stm32l432_ec11.c
+++ b/keyboards/keychron/v8/v8_iso_stm32l432_ec11/v8_iso_stm32l432_ec11.c
@@ -160,6 +160,9 @@ void keyboard_post_init_kb(void) {
     palEnableLineEvent(encoders_pad_b[0], PAL_EVENT_MODE_BOTH_EDGES);
     palSetLineCallback(encoders_pad_a[0], encoder0_pad_cb, NULL);
     palSetLineCallback(encoders_pad_b[0], encoder0_pad_cb, NULL);
+
+    // allow user keymaps to do custom post_init
+    keyboard_post_init_user();
 }
 #    endif // PAL_USE_CALLBACKS
 #endif     // ENCODER_ENABLE


### PR DESCRIPTION
This adds a _user() call to the end of each keyboard_post_init_kb() function in Keychron's keyboards.

This is required to be compliant with upstream QMK.  Without this call, user keymaps cannot run any custom code at boot time in the manner recommended by QMK's documentation.  For example, loading user eeprom values and activating custom RGB code.

For more info:
https://docs.qmk.fm/#/custom_quantum_functions?id=keyboard-post-initialization-code
https://docs.qmk.fm/#/custom_quantum_functions?id=example-implementation

I discovered this issue because my custom keymaps for Keychron devices were unable to load and save config in eeprom, even though the same code worked on hardware from other vendors... and I traced the issue back to a bug in keyboard_post_init_kb().  Fortunately, it's an easy fix.

More generally, all _kb() functions should call the corresponding _user() function.  So it may be a good idea to check for similar bugs elsewhere in the code.  For now though, this at least fixes post_init.