### PR TITLE
moved factory tests to factory keymaps only (default + via)

### DIFF
--- a/keyboards/keychron/q0/q0_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q0/q0_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q0/test.c

--- a/keyboards/keychron/q0/q0_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q0/q0_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q0/test.c

--- a/keyboards/keychron/q0/q0_stm32l432/rules.mk
+++ b/keyboards/keychron/q0/q0_stm32l432/rules.mk
@@ -26,5 +26,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
-
-SRC += ./../factory/secondary/q0/test.c

--- a/keyboards/keychron/q1/q1_ansi_atmega32u4/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_atmega32u4/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_atmega32u4/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_atmega32u4/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_atmega32u4/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_atmega32u4/rules.mk
@@ -22,4 +22,3 @@ RGB_MATRIX_DRIVER = IS31FL3733
 RAW_ENABLE = yes
 LTO_ENABLE = yes
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_atmega32u4_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_atmega32u4_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_atmega32u4_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_atmega32u4_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_atmega32u4_ec11/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_atmega32u4_ec11/rules.mk
@@ -24,4 +24,3 @@ RGB_MATRIX_DRIVER = IS31FL3733
 RAW_ENABLE = yes
 LTO_ENABLE = yes
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q1/q1_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q1/q1_iso_atmega32u4/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_atmega32u4/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_atmega32u4/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_atmega32u4/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_atmega32u4/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_atmega32u4/rules.mk
@@ -22,4 +22,3 @@ RGB_MATRIX_DRIVER = IS31FL3733
 RAW_ENABLE = yes
 LTO_ENABLE = yes
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_atmega32u4_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_atmega32u4_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_atmega32u4_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_atmega32u4_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_atmega32u4_ec11/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_atmega32u4_ec11/rules.mk
@@ -24,4 +24,3 @@ RGB_MATRIX_DRIVER = IS31FL3733
 RAW_ENABLE = yes
 LTO_ENABLE = yes
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q1/q1_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q1/q1_iso_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q1/q1_jis_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_jis_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_jis_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_jis_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_jis_stm32l432/rules.mk
+++ b/keyboards/keychron/q1/q1_jis_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q1/q1_jis_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q1/q1_jis_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_jis_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q1/q1_jis_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q1/q1_jis_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q1/q1_jis_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q10/q10_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q10/q10_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q10/q10_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q10/q10_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q10/q10_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q10/q10_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q10/q10_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q10/q10_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q10/q10_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q10/q10_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q10/q10_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q10/q10_iso_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q2/q2_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q2/q2_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q2/q2_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q2/q2_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q2/q2_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q2/q2_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q2/q2_ansi_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q2/q2_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q2/q2_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q2/q2_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q2/q2_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q2/q2_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q2/q2_iso_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_jis_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q2/q2_jis_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_jis_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q2/q2_jis_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_jis_stm32l432/rules.mk
+++ b/keyboards/keychron/q2/q2_jis_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_jis_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q2/q2_jis_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_jis_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q2/q2_jis_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q2/q2_jis_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q2/q2_jis_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q3/q3_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q3/q3_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q3/q3_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q3/q3_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/q3/q3_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q3/q3_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q3/q3_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q3/q3_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,3 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c

--- a/keyboards/keychron/q3/q3_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q3/q3_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q3/q3_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q3/q3_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/q3/q3_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q3/q3_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q3/q3_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q3/q3_iso_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q3/q3_jis_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q3/q3_jis_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_jis_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q3/q3_jis_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_jis_stm32l432/rules.mk
+++ b/keyboards/keychron/q3/q3_jis_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/q3/q3_jis_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q3/q3_jis_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_jis_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q3/q3_jis_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q3/q3_jis_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q3/q3_jis_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q4/q4_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q4/q4_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q4/q4_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q4/q4_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q4/q4_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q4/q4_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q4/q4_rev1_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q4/q4_rev1_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q4/q4_rev1_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q4/q4_rev1_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q4/q4_rev1_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q4/q4_rev1_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q4/q4_rev2_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q4/q4_rev2_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q4/q4_rev2_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q4/q4_rev2_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q4/q4_rev2_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q4/q4_rev2_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q5/q5_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q5/q5_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q5/q5_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q5/q5_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q5/q5_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q5/q5_ansi_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q5/q5_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q5/q5_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q5/q5_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q5/q5_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q5/q5_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q5/q5_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q5/q5_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q5/q5_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q5/q5_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q5/q5_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q5/q5_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q5/q5_iso_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q5/q5_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q5/q5_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q5/q5_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q5/q5_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q5/q5_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q5/q5_iso_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q6/q6_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q6/q6_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q6/q6_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q6/q6_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q6/q6_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q6/q6_ansi_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q6/q6_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q6/q6_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q6/q6_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q6/q6_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q6/q6_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q6/q6_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q6/q6_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q6/q6_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q6/q6_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q6/q6_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q6/q6_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q6/q6_iso_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q6/q6_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q6/q6_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/q6/q6_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q6/q6_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/q6/q6_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q6/q6_iso_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q65/q65_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q65/q65_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q65/q65_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q65/q65_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q65/q65_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q65/q65_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/secondary/q2/test.c
+SRC += matrix.c

--- a/keyboards/keychron/q7/q7_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q7/q7_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q7/q7_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q7/q7_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q7/q7_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q7/q7_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q7/q7_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q7/q7_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q7/q7_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q7/q7_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q7/q7_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q7/q7_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q8/q8_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q8/q8_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q8/q8_ansi_stm32l432/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q8/q8_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q8/q8_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q8/q8_ansi_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q8/q8_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q8/q8_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q8/q8_iso_stm32l432/rules.mk
@@ -28,4 +28,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q8/q8_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q8/q8_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/q8/q8_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q8/q8_iso_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/q9/q9_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q9/q9_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q9/q9_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/q9/q9_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q9/q9_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q9/q9_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q9/q9_ansi_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/q9/q9_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/q9/q9_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/q9/q9_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/q9/q9_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/q9/q9_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q9/test.c

--- a/keyboards/keychron/q9/q9_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/q9/q9_iso_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q9/test.c

--- a/keyboards/keychron/s1/s1_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/s1/s1_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/s1/s1_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/s1/s1_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/s1/s1_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/s1/s1_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/v1/v1_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v1/v1_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v1/v1_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/v1/v1_ansi_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v1/v1_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v1/v1_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v1/v1_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v1/v1_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/v1/v1_iso_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v1/v1_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v1/v1_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v1/v1_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v1/v1_iso_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v1/v1_jis_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v1/v1_jis_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_jis_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v1/v1_jis_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_jis_stm32l432/rules.mk
+++ b/keyboards/keychron/v1/v1_jis_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v1/v1_jis_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v1/v1_jis_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_jis_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v1/v1_jis_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v1/v1_jis_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v1/v1_jis_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v2/v2_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v2/v2_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v2/v2_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/v2/v2_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v2/v2_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v2/v2_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v2/v2_ansi_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v2/v2_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v2/v2_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/v2/v2_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v2/v2_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v2/v2_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v2/v2_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v2/v2_iso_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v3/v3_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v3/v3_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v3/v3_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v3/v3_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v3/v3_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/v3/v3_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/v3/v3_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v3/v3_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v3/v3_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v3/v3_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v3/v3_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v3/v3_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v3/v3_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v3/v3_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v3/v3_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v3/v3_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v3/v3_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/v3/v3_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/major/test.c

--- a/keyboards/keychron/v3/v3_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v3/v3_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v3/v3_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v3/v3_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v3/v3_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v3/v3_iso_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v4/v4_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v4/v4_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v4/v4_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v4/v4_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v4/v4_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/v4/v4_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v4/v4_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v4/v4_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v4/v4_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v4/v4_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v4/v4_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/v4/v4_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v5/v5_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v5/v5_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v5/v5_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v5/v5_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v5/v5_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/v5/v5_ansi_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v5/v5_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v5/v5_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v5/v5_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v5/v5_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v5/v5_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v5/v5_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v5/v5_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v5/v5_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v5/v5_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v5/v5_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v5/v5_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/v5/v5_iso_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v5/v5_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v5/v5_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v5/v5_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v5/v5_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v5/v5_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v5/v5_iso_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v6/v6_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v6/v6_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v6/v6_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v6/v6_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v6/v6_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/v6/v6_ansi_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v6/v6_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v6/v6_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v6/v6_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v6/v6_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v6/v6_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v6/v6_ansi_stm32l432_ec11/rules.mk
@@ -32,4 +32,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v6/v6_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v6/v6_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/major/test.c

--- a/keyboards/keychron/v6/v6_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v6/v6_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/major/test.c

--- a/keyboards/keychron/v6/v6_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/v6/v6_iso_stm32l432/rules.mk
@@ -30,4 +30,4 @@ OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 # custom matrix setup
 CUSTOM_MATRIX = lite
 
-SRC += matrix.c ./../factory/major/test.c
+SRC += matrix.c

--- a/keyboards/keychron/v7/v7_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v7/v7_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v7/v7_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v7/v7_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v7/v7_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/v7/v7_ansi_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v7/v7_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v7/v7_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v7/v7_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v7/v7_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v7/v7_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/v7/v7_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_ansi_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v8/v8_ansi_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_ansi_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v8/v8_ansi_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_ansi_stm32l432/rules.mk
+++ b/keyboards/keychron/v8/v8_ansi_stm32l432/rules.mk
@@ -30,4 +30,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_ansi_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v8/v8_ansi_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_ansi_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v8/v8_ansi_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_ansi_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v8/v8_ansi_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_iso_stm32l432/keymaps/default/rules.mk
+++ b/keyboards/keychron/v8/v8_iso_stm32l432/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_iso_stm32l432/keymaps/via/rules.mk
+++ b/keyboards/keychron/v8/v8_iso_stm32l432/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_iso_stm32l432/rules.mk
+++ b/keyboards/keychron/v8/v8_iso_stm32l432/rules.mk
@@ -27,4 +27,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_iso_stm32l432_ec11/keymaps/default/rules.mk
+++ b/keyboards/keychron/v8/v8_iso_stm32l432_ec11/keymaps/default/rules.mk
@@ -1,0 +1,1 @@
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_iso_stm32l432_ec11/keymaps/via/rules.mk
+++ b/keyboards/keychron/v8/v8_iso_stm32l432_ec11/keymaps/via/rules.mk
@@ -1,1 +1,2 @@
 VIA_ENABLE = yes
+SRC += factory/secondary/q2/test.c

--- a/keyboards/keychron/v8/v8_iso_stm32l432_ec11/rules.mk
+++ b/keyboards/keychron/v8/v8_iso_stm32l432_ec11/rules.mk
@@ -29,4 +29,3 @@ WEAR_LEVELING_DRIVER = embedded_flash
 # Enter lower-power sleep mode when on the ChibiOS idle thread
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
 
-SRC += ./../factory/secondary/q2/test.c


### PR DESCRIPTION
Factory tests don't belong in user keymaps, and they break several user keymap functions, so I changed the build options to include test.c only in the "default" and "via" keymaps.

In particular, all the _user() functions in factory/*/test.c interfere with user keymap functions.  Those should probably be _kb() functions instead.

More generally, user keymaps don't need any factory test functionality, so factory test.c code should only be included in the factory default firmware.

In my personal keymap, I use rgb_matrix_indicators_advanced_user() to give the keyboard some customized lighting effects... but the factory test code breaks it.  I can't compile unless I remove test.c.

Similar changes also need to be applied to the new Q60 and V10 boards... but the current playground HEAD revision doesn't compile, so I applied these changes to the most recent rev which compiles and works.


## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation
