### PR TITLE
Included NEW_SAFE_RANGE in Keychron K series enums

### DIFF
--- a/keyboards/keychron/k2_pro/k2_pro.h
+++ b/keyboards/keychron/k2_pro/k2_pro.h
@@ -48,6 +48,7 @@ enum {
     BT_HST3,
 #endif
     BAT_LVL,
+	NEW_SAFE_RANGE,
 };
 
 #define LAYOUT_ansi_84( \

--- a/keyboards/keychron/k6_pro/k6_pro.h
+++ b/keyboards/keychron/k6_pro/k6_pro.h
@@ -48,6 +48,7 @@ enum {
     BT_HST3,
 #endif
     BAT_LVL,
+	NEW_SAFE_RANGE,
 };
 
 #define LAYOUT_ansi_68( \

--- a/keyboards/keychron/k8_pro/k8_pro.h
+++ b/keyboards/keychron/k8_pro/k8_pro.h
@@ -48,6 +48,7 @@ enum {
     BT_HST3,
 #endif
     BAT_LVL,
+	NEW_SAFE_RANGE,
 };
 
 #define LAYOUT_ansi_87( \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

Following guidance from QMK docs (https://docs.qmk.fm/#/configurator_default_keymaps?id=custom-keycodes) included NEW_SAFE_RANGE at the end of the enum defining vendor level custom keycodes for K-series boards.  This ensures that when users define their own keymaps, if they start at NEW_SAFE_RANGE, that their codes will not collide with vendor codes.  This is especially true if the vendor adds or removes codes in future updates.

<!--- Describe your changes in detail here. -->

In each K-series board header I added a final entry into the custom keycode enum called NEW_SAFE_RANGE.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Users defining custom keymaps will easily run into conflicts with the keycodes defined by the vendor.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
