### PR TITLE
fix: K6 Pro ANSI White LEDS

### DIFF
--- a/keyboards/keychron/k6_pro/ansi/white/config.h
+++ b/keyboards/keychron/k6_pro/ansi/white/config.h
@@ -31,7 +31,7 @@
 
 
 #    define DIM_CAPS_LOCK
-#    define CAPS_LOCK_INDEX    46
+#    define CAPS_LOCK_INDEX    30
 #    define LOW_BAT_IND_INDEX 61
 
 /* LED Matrix Animation modes. Explicitly enabled

--- a/keyboards/keychron/k6_pro/ansi/white/white.c
+++ b/keyboards/keychron/k6_pro/ansi/white/white.c
@@ -89,6 +89,7 @@ const ckled2001_led g_ckled2001_leds[LED_MATRIX_LED_COUNT] = {
     {0, F_15},
     {0, F_14},
     {0, F_10},
+    {0, F_7},
     {0, F_6},
     {0, F_5},
     {0, F_4},


### PR DESCRIPTION
fix: K6 Pro ANSI White LEDS
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
- Wrong CAPS_LOCK_INDEX in keyboards/keychron/k6_pro/ansi/white/config.h
- Missing right-CMD LED address in keyboards/keychron/k6_pro/ansi/white/white.c

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
