### PR TITLE
Allow overwrite led indicator at user level

### DIFF
--- a/keyboards/keychron/bluetooth/indicator.c
+++ b/keyboards/keychron/bluetooth/indicator.c
@@ -558,7 +558,7 @@ bool LED_INDICATORS_KB(void) {
    return false;
 }
 
-bool led_update_user(led_t led_state) {
+bool led_update_kb(led_t led_state) {
     if (!LED_DRIVER_IS_ENABLED()) {
 #    if defined(LED_MATRIX_DRIVER_SHUTDOWN_ENABLE) || defined(RGB_MATRIX_DRIVER_SHUTDOWN_ENABLE)
         LED_DRIVER.exit_shutdown();


### PR DESCRIPTION
## Simple change to allow user level override of `led_update_user()` in `indicator.c`

I have an RGB-enabled K3 Pro, which has 2 LEDs under the caps lock key: 1 red LED and 1 RGB LED. I wanted to turn off the red caps lock LED indicator and have only my own chosen RGB color light up when caps is enabled. I figured out how to do that, _except_ that when I try to implement my own `led_update_user()` I get a compiler error. It directs me to `indicator.c:561`, where I see the function is already defined.

Seems like this function in the `indicator.c` file should be called `led_update_kb()`.

I was able to fix my problem, but it required me to modify code at the keyboard level, while my understanding is that I shouldn't be doing that kind of thing for my own personal keymap.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
