### PR TITLE
Add missing include keychron_common.h for ansi_encoder

### DIFF
--- a/keyboards/keychron/q10/q10.c
+++ b/keyboards/keychron/q10/q10.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b1111111111111111,

--- a/keyboards/keychron/q12/q12.c
+++ b/keyboards/keychron/q12/q12.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 // clang-format off
 const matrix_row_t matrix_mask[] = {

--- a/keyboards/keychron/q5/q5.c
+++ b/keyboards/keychron/q5/q5.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b111111111111111111,

--- a/keyboards/keychron/q6/q6.c
+++ b/keyboards/keychron/q6/q6.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b11111111111111111111,

--- a/keyboards/keychron/q65/q65.c
+++ b/keyboards/keychron/q65/q65.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b1111111111111111,

--- a/keyboards/keychron/q8/q8.c
+++ b/keyboards/keychron/q8/q8.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b111111111111111,

--- a/keyboards/keychron/q9/q9.c
+++ b/keyboards/keychron/q9/q9.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b111111111111111,

--- a/keyboards/keychron/v1/v1.c
+++ b/keyboards/keychron/v1/v1.c
@@ -38,6 +38,7 @@ bool dip_switch_update_kb(uint8_t index, bool active) {
 #endif
 
 #if defined(ENCODER_ENABLE) && defined(PAL_USE_CALLBACKS)
+#include "keychron_common.h"
 
 void keyboard_post_init_kb(void) {
     keyboard_post_init_keychron();

--- a/keyboards/keychron/v10/v10.c
+++ b/keyboards/keychron/v10/v10.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b1111111111111111,

--- a/keyboards/keychron/v2/v2.c
+++ b/keyboards/keychron/v2/v2.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b111111111111111,

--- a/keyboards/keychron/v3/v3.c
+++ b/keyboards/keychron/v3/v3.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 // clang-format off
 

--- a/keyboards/keychron/v5/v5.c
+++ b/keyboards/keychron/v5/v5.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b111111111111111111,

--- a/keyboards/keychron/v6/v6.c
+++ b/keyboards/keychron/v6/v6.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 // clang-format off
 const matrix_row_t matrix_mask[] = {

--- a/keyboards/keychron/v8/v8.c
+++ b/keyboards/keychron/v8/v8.c
@@ -15,6 +15,7 @@
  */
 
 #include "quantum.h"
+#include "keychron_common.h"
 
 const matrix_row_t matrix_mask[] = {
     0b111111111111111,


### PR DESCRIPTION
## Description
When building, an error like this appears:
> qmk compile -kb keychron/v6/ansi_encoder -km keychron
```
Ψ Compiling keymap with gmake --jobs=1 keychron/v6/ansi_encoder:keychron


QMK Firmware 0.14.29
Making keychron/v6/ansi_encoder with keymap keychron

arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 8-2019-q3-update) 8.3.1 20190703 (release) [gcc-8-branch revision 273027]
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Generating: .build/obj_keychron_v6_ansi_encoder/src/info_config.h                                   [OK]
Generating: .build/obj_keychron_v6_ansi_encoder/src/default_keyboard.c                              [OK]
Generating: .build/obj_keychron_v6_ansi_encoder/src/default_keyboard.h                              [OK]
Compiling: keyboards/keychron/common/matrix.c                                                       [OK]
Compiling: keyboards/keychron/common/keychron_common.c                                              [OK]
Compiling: keyboards/keychron/common/keychron_ft_common.c                                           [OK]
Compiling: keyboards/keychron/v6/v6.c                                                              keyboards/keychron/v6/v6.c: In function 'keyboard_post_init_kb':
keyboards/keychron/v6/v6.c:48:5: error: implicit declaration of function 'keyboard_post_init_keychron'; did you mean 'keyboard_post_init_user'? [-Werror=implicit-function-declaration]
     keyboard_post_init_keychron();
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
     keyboard_post_init_user
cc1: all warnings being treated as errors
 [ERRORS]
 |
 |
 |
gmake[1]: *** [builddefs/common_rules.mk:360: .build/obj_keychron_v6_ansi_encoder_keychron/keyboards/keychron/v6/v6.o] Error 1
Make finished with errors
gmake: *** [Makefile:392: keychron/v6/ansi_encoder:keychron] Error 1
```

This is because the file was not included. IMHO, it could be wrapped in the ifdef statement.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
