### PR TITLE
Add buffer keypress on reconnecting state in bluetooth mode

### DIFF
--- a/keyboards/keychron/bluetooth/bluetooth.mk
+++ b/keyboards/keychron/bluetooth/bluetooth.mk
@@ -14,10 +14,14 @@ SRC += \
      $(BLUETOOTH_DIR)/battery.c \
      $(BLUETOOTH_DIR)/factory_test.c \
      $(BLUETOOTH_DIR)/bat_level_animation.c \
-     $(BLUETOOTH_DIR)/rtc_timer.c
+     $(BLUETOOTH_DIR)/rtc_timer.c \
+     $(BLUETOOTH_DIR)/bluetooth_ee.c
 
 VPATH += $(TOP_DIR)/keyboards/keychron/$(BLUETOOTH_DIR)
 
 # Work around RTC clock issue without touching chibios, refer to the link for this bug
 # https://forum.chibios.org/viewtopic.php?f=35&t=6197
 OPT_DEFS += -DRCC_APBENR1_RTCAPBEN
+
+# Workaround for Bluetooth EE Prom without editing every keyboard config.h
+OPT_DEFS += -DEECONFIG_KB_DATA_SIZE=1

--- a/keyboards/keychron/bluetooth/bluetooth_ee.c
+++ b/keyboards/keychron/bluetooth/bluetooth_ee.c
@@ -1,0 +1,95 @@
+#include "bluetooth_ee.h"
+#include "eeconfig.h"
+#include "quantum.h"
+
+bluetooth_ee_config_t bluetooth_ee_config;
+
+void bluetooth_ee_reconnect_buffer_enable(void) {
+    bluetooth_ee_config.reconnect_buffer_enabled = true;
+}
+
+void bluetooth_ee_reconnect_buffer_disable(void) {
+    bluetooth_ee_config.reconnect_buffer_enabled = false;
+}
+
+bool bluetooth_ee_reconnect_buffer_is_enabled(void) {
+    return bluetooth_ee_config.reconnect_buffer_enabled;
+}
+
+/* EE Config Init */
+void eeconfig_init_kb(void) {
+    /* Set Default Value */
+    bluetooth_ee_config.reconnect_buffer_enabled = true;
+
+    eeconfig_update_kb_datablock(&bluetooth_ee_config);
+    eeconfig_init_user();
+}
+
+void bluetooth_ee_init(void) {
+    eeconfig_read_kb_datablock(&bluetooth_ee_config);
+}
+
+/* Via Command */
+#ifdef VIA_ENABLE
+
+void via_custom_value_command_kb(uint8_t *data, uint8_t length) {
+    uint8_t *command_id        = &(data[0]);
+    uint8_t *channel_id        = &(data[1]);
+    uint8_t *value_id_and_data = &(data[2]);
+
+    if ( *channel_id == id_custom_channel ) {
+        switch ( *command_id ) {
+            case id_custom_set_value: {
+                via_bluetooth_ee_set_value(value_id_and_data);
+                break;
+            }
+            case id_custom_get_value: {
+                via_bluetooth_ee_get_value(value_id_and_data);
+                break;
+            }
+            case id_custom_save: {
+                via_bluetooth_ee_save();
+                break;
+            }
+            default: {
+                *command_id = id_unhandled;
+                break;
+            }
+        }
+
+        return;
+    }
+
+    // Return the unhandled state
+    *command_id = id_unhandled;
+}
+
+void via_bluetooth_ee_get_value(uint8_t *data) {
+    /* data = [ value_id, value_data ] */
+    uint8_t *value_id   = &(data[0]);
+    uint8_t *value_data = &(data[1]);
+    switch (*value_id) {
+        case id_kc_bluetooth_reconnect_buffer: {
+            value_data[0] = bluetooth_ee_reconnect_buffer_is_enabled() ? 1 : 0;
+            break;
+        }
+    }
+}
+
+void via_bluetooth_ee_set_value(uint8_t *data) {
+    /* data = [ value_id, value_data ] */
+    uint8_t *value_id   = &(data[0]);
+    uint8_t *value_data = &(data[1]);
+    switch (*value_id) {
+        case id_kc_bluetooth_reconnect_buffer: {
+            value_data[0] ? bluetooth_ee_reconnect_buffer_enable() : bluetooth_ee_reconnect_buffer_disable();
+            break;
+        }
+    }
+}
+
+void via_bluetooth_ee_save(void) {
+    eeconfig_update_kb_datablock(&bluetooth_ee_config);
+}
+
+#endif

--- a/keyboards/keychron/bluetooth/bluetooth_ee.h
+++ b/keyboards/keychron/bluetooth/bluetooth_ee.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifndef EECONFIG_KB_DATA_SIZE
+#   define EECONFIG_KB_DATA_SIZE 1
+#endif
+
+void bluetooth_ee_init(void);
+
+/* Reconnect Buffer Function */
+typedef struct {
+    bool reconnect_buffer_enabled;
+} bluetooth_ee_config_t;
+
+void bluetooth_ee_reconnect_buffer_enable(void);
+void bluetooth_ee_reconnect_buffer_disable(void);
+bool bluetooth_ee_reconnect_buffer_is_enabled(void);
+
+/* Via Command */
+#ifdef VIA_ENABLE
+enum via_bluetooth_ee_value {
+    id_kc_bluetooth_reconnect_buffer = 1,
+};
+
+void via_bluetooth_ee_set_value(uint8_t *data);
+void via_bluetooth_ee_get_value(uint8_t *data);
+void via_bluetooth_ee_save(void);
+#endif

--- a/keyboards/keychron/q6_pro/via_json/q6_pro_ansi_encoder.json
+++ b/keyboards/keychron/q6_pro/via_json/q6_pro_ansi_encoder.json
@@ -62,6 +62,21 @@
           ]
         }
       ]
+    },
+    {
+      "label": "Bluetooth",
+      "content": [
+        {
+          "label": "Buffer",
+          "content": [
+            {
+              "label": "Reconnect Buffer",
+              "type": "toggle",
+              "content": ["id_kc_bluetooth_reconnect_buffer", 0, 1]
+            }
+          ]
+        }
+      ]
     }
   ],
   "customKeycodes": [

--- a/keyboards/keychron/q6_pro/via_json/q6_pro_iso_encoder.json
+++ b/keyboards/keychron/q6_pro/via_json/q6_pro_iso_encoder.json
@@ -62,6 +62,21 @@
           ]
         }
       ]
+    },
+    {
+      "label": "Bluetooth",
+      "content": [
+        {
+          "label": "Buffer",
+          "content": [
+            {
+              "label": "Reconnect Buffer",
+              "type": "toggle",
+              "content": ["id_kc_bluetooth_reconnect_buffer", 0, 1]
+            }
+          ]
+        }
+      ]
     }
   ],
   "customKeycodes": [


### PR DESCRIPTION
## Description

Since I use other wireless before. The bluetooth behaviour is kinda stick to me, so the behaviour is that before the bluetooth sucessfully reconnect, the keyboard will buffer the keypress. And when it sucessfully reconnect, it will send the key.

So I decided to copy the logic / behaviour here, and since the buffer function is already there, I think we just need to reuse the function when the state is RECONNECTING.

I already built and used the firmware in Q6 Pro just today, works well but I can't debug so I will try it a little bit longer.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
