### PR TITLE
Don't turn on OS state indicator LEDs when suspending.

### DIFF
--- a/quantum/led_matrix/led_matrix.c
+++ b/quantum/led_matrix/led_matrix.c
@@ -485,11 +485,18 @@ void led_matrix_init(void) {
 
 void led_matrix_set_suspend_state(bool state) {
 #ifdef LED_DISABLE_WHEN_USB_SUSPENDED
-    if (state && !suspend_state && is_keyboard_master()) { // only run if turning off, and only once
+    /* Store suspend state before calling led_task_render.
+     * This way, led_matrix_none_indicators_{kb,user} can differentiate
+     * between regular operation with mode == LED_MATRIX_NONE and
+     * suspending.
+     */
+    bool suspending = state && !suspend_state;
+    suspend_state = state;
+
+    if (suspending && is_keyboard_master()) {              // only run if turning off, and only once
         led_task_render(0);                                // turn off all LEDs when suspending
         led_task_flush(0);                                 // and actually flash led state to LEDs
     }
-    suspend_state = state;
 #endif
 }
 

--- a/quantum/rgb_matrix/rgb_matrix.c
+++ b/quantum/rgb_matrix/rgb_matrix.c
@@ -544,11 +544,18 @@ void rgb_matrix_init(void) {
 
 void rgb_matrix_set_suspend_state(bool state) {
 #ifdef RGB_DISABLE_WHEN_USB_SUSPENDED
-    if (state && !suspend_state) { // only run if turning off, and only once
+    /* Store suspend state before calling rgb_task_render.
+     * This way, rgb_matrix_none_indicators_{kb,user} can differentiate
+     * between regular operation with mode == RGB_MATRIX_NONE and
+     * suspending.
+     */
+    bool suspending = state && !suspend_state;
+    suspend_state = state;
+
+    if (suspending) {              // only run if turning off, and only once
         rgb_task_render(0);        // turn off all LEDs when suspending
         rgb_task_flush(0);         // and actually flash led state to LEDs
     }
-    suspend_state = state;
 #endif
 }
 


### PR DESCRIPTION
## Description

Added a check to os_state_indicate and LED_DRIVER_ALLOW_SHUTDOWN. This check disables turning on the OS state indicators (i.e. numlock backlight) when suspending (i.e. when the host is going to sleep), and allows the matrix driver to be shut down.

For these changes to work, rgb_matrix_set_suspend_state and led_matrix_set_suspend_state are modified so they store the suspend state before (indirectly) calling the modified functions.

The changes have been tested on a K10 Pro over both USB and Bluetooth. The led_matrix code has only been compile tested since I have no access to hardware which uses it.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

#188

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
