### PR TITLE
fix custom keycode enum in keychron_common.h

### DIFF
--- a/keyboards/keychron/common/keychron_common.h
+++ b/keyboards/keychron/common/keychron_common.h
@@ -46,6 +46,19 @@ enum {
     NEW_SAFE_RANGE,
 };
 
+#ifndef LK_WIRELESS_ENABLE
+    #define BT_HST1     KC_TRANS
+    #define BT_HST2     KC_TRANS
+    #define BT_HST3     KC_TRANS
+    #define P2P4G       KC_TRANS
+    #define BAT_LVL     KC_TRANS
+#endif
+#ifndef ANANLOG_MATRIX
+    #define PROF1 KC_TRANS
+    #define PROF2 KC_TRANS
+    #define PROF3 KC_TRANS
+#endif
+
 #define KC_TASK KC_TASK_VIEW
 #define KC_FILE KC_FILE_EXPLORER
 #define KC_SNAP KC_SCREEN_SHOT

--- a/keyboards/keychron/common/keychron_common.h
+++ b/keyboards/keychron/common/keychron_common.h
@@ -37,21 +37,11 @@ enum {
     BT_HST3,
     P2P4G,
     BAT_LVL,
-#else
-    BT_HST1 = _______,
-    BT_HST2 = _______,
-    BT_HST3 = _______,
-    P2P4G   = _______,
-    BAT_LVL = _______,
 #endif
-#ifdef DANANLOG_MATRIX
+#ifdef ANANLOG_MATRIX
     PROF1,
     PROF2,
     PROF3,
-#else
-    PROF1 = _______,
-    PROF2 = _______,
-    PROF3 = _______,
 #endif
     NEW_SAFE_RANGE,
 };


### PR DESCRIPTION
- This removes the KC_TRANS assignments for keys not existing on keyboards that do not define ANANLOG_MATRIX and or LK_WIRELESS_ENABLE. 
Assigning KC_TRANS here breaks NEW_SAFE_RANGE since NEW_SAFE_RANGE now eqals `KC_TRANS + 1 = 0x2` instead of QK_KB_NN where NN is the next unused value in the QK_KB range.

- Also fix typo in ANANLOG_MATRIX
