### PR TITLE
Use expected LED indices for host and battery indicators on Q2 Pro

### DIFF
--- a/keyboards/keychron/q2_pro/config.h
+++ b/keyboards/keychron/q2_pro/config.h
@@ -47,10 +47,10 @@
 #        define LED_DRIVER_SHUTDOWN_PIN C14
 
 #        define HOST_LED_MATRIX_LIST \
-            { 16, 17, 18 }
+            { 15, 16, 17 }
 
 #        define BAT_LEVEL_LED_LIST \
-            { 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 }
+            { 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 }
 
 /* Backlit disable timeout when keyboard is disconnected(unit: second) */
 #        define DISCONNECTED_BACKLIGHT_DISABLE_TIMEOUT 40

--- a/keyboards/keychron/q2_pro/config.h
+++ b/keyboards/keychron/q2_pro/config.h
@@ -50,7 +50,7 @@
             { 15, 16, 17 }
 
 #        define BAT_LEVEL_LED_LIST \
-            { 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 }
+            { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
 /* Backlit disable timeout when keyboard is disconnected(unit: second) */
 #        define DISCONNECTED_BACKLIGHT_DISABLE_TIMEOUT 40


### PR DESCRIPTION
When building for the Q2 Pro using the included ansi_encoder default or via keymaps:

1. the bluetooth hosts assigned to the Q, W, and E keys light up the indicators on the W, E, and R keys
2. the battery level indicators range from W to [, not Q to P as expected

I believe the LED index that lines up with Q is 15, not 16.