### PR TITLE
Q3 Pro DIP switch custom behavior

### DIFF
--- a/keyboards/keychron/bluetooth/factory_test.c
+++ b/keyboards/keychron/bluetooth/factory_test.c
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#if defined(ENABLE_FACTORY_TEST)
+
 #include "quantum.h"
 #include "raw_hid.h"
 #ifdef KC_BLUETOOTH_ENABLE
@@ -343,3 +345,5 @@ bool dip_switch_update_user(uint8_t index, bool active) {
     return true;
 }
 #endif
+
+#endif //ENABLE_FACTORY_TEST

--- a/keyboards/keychron/bluetooth/factory_test.c
+++ b/keyboards/keychron/bluetooth/factory_test.c
@@ -330,6 +330,7 @@ void factory_test_rx(uint8_t *data, uint8_t length) {
     }
 }
 
+#if !defined(KEYCHRON_DIP_SWITCH_USER)
 bool dip_switch_update_user(uint8_t index, bool active) {
     if (report_os_sw_state) {
 #ifdef INVERT_OS_SWITCH_STATE
@@ -341,3 +342,4 @@ bool dip_switch_update_user(uint8_t index, bool active) {
 
     return true;
 }
+#endif

--- a/keyboards/keychron/q3_pro/q3_pro.c
+++ b/keyboards/keychron/q3_pro/q3_pro.c
@@ -64,12 +64,12 @@ static void pairing_key_timer_cb(void *arg) {
 
 #ifdef DIP_SWITCH_ENABLE
 bool dip_switch_update_kb(uint8_t index, bool active) {
+#if !defined(KEYCHRON_DIP_SWITCH_USER)
     if (index == 0) {
         default_layer_set(1UL << (active ? 2 : 0));
     }
-    dip_switch_update_user(index, active);
-
-    return true;
+#endif
+    return dip_switch_update_user(index, active);
 }
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Currently is not possible to disable or override original Win/Mac DIP behavior in custom keymaps code, these changes allow that so that DIP switch can be used in different ways.
<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [X] Keyboard (addition or update)
- [X] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
