### PR TITLE
Fix failing to init submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "lib/chibios"]
 	path = lib/chibios
 	url = https://github.com/Keychron/ChibiOS.git
-	branch = master
+	branch = fix_STM32F401
 [submodule "lib/chibios-contrib"]
 	path = lib/chibios-contrib
 	url = https://github.com/qmk/ChibiOS-Contrib


### PR DESCRIPTION
The commit 86a3ed9baf621c19b72fdcd7429a88c9f3237a1f is on branch fix_STM32F401, not master. This needs to be correctly pointed in order to be able to init submodules & build.