### PR TITLE
Fix analogue sticks

### DIFF
--- a/keyboards/keychron/common/analog_matrix/action_joystick.c
+++ b/keyboards/keychron/common/analog_matrix/action_joystick.c
@@ -175,6 +175,8 @@ static void joystick_action(void) {
             else
                 joystick_set_axis(i, axis_value[i]);
         }
+
+        joystick_flush();
     }
 }
 


### PR DESCRIPTION
A joystick report was only being sent when a digital button was being pressed, not when an analogue stick or trigger has changed position.