### PR TITLE
Support for hall effect mouse keys.

### DIFF
--- a/keyboards/keychron/common/analog_matrix/analog_matrix_scan.c
+++ b/keyboards/keychron/common/analog_matrix/analog_matrix_scan.c
@@ -22,6 +22,8 @@
 #include "debounce.h"
 #include "lpm.h"
 
+#include <keychron_common.h>
+
 #ifndef HC164_DS
 #    define HC164_DS B3
 #endif
@@ -160,6 +162,21 @@ void matrix_read_rows_on_col(uint8_t current_col, matrix_row_t row_shifter) {
             if (pressed) {
                 if ((analog_raw_matrix[row_index] & row_mask) == 0)
                     changed = true;
+
+                if (is_mouse_key(current_col, row_index)) {
+                    uint8_t travel = analog_matrix_get_travel(row_index, current_col)/TRAVEL_SCALE;
+                    uint8_t mouse_speed = ((travel * travel + travel) * 4) / 100;
+                    if (mouse_speed == 0)
+                        mouse_speed = 1;
+                    if (mouse_speed > 200)
+                        mouse_speed = 200;
+                    if (is_vertical_mouse_key(current_col, row_index)) {
+                        mousekey_set_speed_y(mouse_speed);
+                    } else {
+                        mousekey_set_speed_x(mouse_speed);
+                    }
+                }
+
 
                 if (debouce_times == ANALOG_DEBOUCE_TIME) {
                     row_value |= (0x01 << row_index);

--- a/keyboards/keychron/common/analog_matrix/analog_matrix_scan.c
+++ b/keyboards/keychron/common/analog_matrix/analog_matrix_scan.c
@@ -163,20 +163,33 @@ void matrix_read_rows_on_col(uint8_t current_col, matrix_row_t row_shifter) {
                 if ((analog_raw_matrix[row_index] & row_mask) == 0)
                     changed = true;
 
-                if (is_mouse_key(current_col, row_index)) {
+                uint16_t mouse_keycode = is_mouse_key(current_col, row_index);
+                if (mouse_keycode>0) {
                     uint8_t travel = analog_matrix_get_travel(row_index, current_col)/TRAVEL_SCALE;
                     uint8_t mouse_speed = ((travel * travel + travel) * 4) / 100;
                     if (mouse_speed == 0)
                         mouse_speed = 1;
                     if (mouse_speed > 200)
                         mouse_speed = 200;
-                    if (is_vertical_mouse_key(current_col, row_index)) {
-                        mousekey_set_speed_y(mouse_speed);
-                    } else {
-                        mousekey_set_speed_x(mouse_speed);
+                    switch (mouse_keycode) {
+                        case KC_MS_UP:
+                        case KC_MS_DOWN:
+                            mousekey_set_speed_y(mouse_speed);
+                            break;
+                        case KC_MS_LEFT:
+                        case KC_MS_RIGHT:
+                            mousekey_set_speed_x(mouse_speed);
+                            break;
+                        case KC_MS_WH_UP:
+                        case KC_MS_WH_DOWN:
+                            mousekey_set_speed_v(mouse_speed);
+                            break;
+                        case KC_MS_WH_LEFT:
+                        case KC_MS_WH_RIGHT:
+                            mousekey_set_speed_h(mouse_speed);
+                            break;
                     }
                 }
-
 
                 if (debouce_times == ANALOG_DEBOUCE_TIME) {
                     row_value |= (0x01 << row_index);

--- a/keyboards/keychron/common/keychron_common.c
+++ b/keyboards/keychron/common/keychron_common.c
@@ -48,6 +48,39 @@ static key_combination_t key_comb_list[4] = {
     {2, {KC_LWIN, KC_C}},
 };
 
+// A struct that stores col and row
+typedef struct {
+    uint8_t col;
+    uint8_t row;
+} key_pos_t;
+
+// An array for the 4 keys, all set to 255, 255 by default using key_post_t
+key_pos_t mouse_keys_pos[4] = {
+    {255, 255},
+    {255, 255},
+    {255, 255},
+    {255, 255},
+};
+
+void set_mouse_key_last_key_pos(uint8_t pos, uint8_t col, uint8_t row) {
+    if (pos>3) return;
+    mouse_keys_pos[pos].col = col;
+    mouse_keys_pos[pos].row = row;
+}
+
+inline bool is_mouse_key(uint8_t col, uint8_t row) {
+   for (uint8_t i = 0; i < 4; i++) {
+        if (mouse_keys_pos[i].col == col && mouse_keys_pos[i].row == row) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool is_vertical_mouse_key(uint8_t col, uint8_t row) {
+    return (mouse_keys_pos[0].col == col && mouse_keys_pos[0].row == row) || (mouse_keys_pos[1].col == col && mouse_keys_pos[1].row == row);
+}
+
 bool process_record_keychron_common(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case KC_MCTRL:
@@ -100,7 +133,18 @@ bool process_record_keychron_common(uint16_t keycode, keyrecord_t *record) {
                 }
             }
             return false; // Skip all further processing of this key
-
+        case KC_MS_UP:
+            set_mouse_key_last_key_pos(0, record->event.key.col, record->event.key.row);
+            break;
+        case KC_MS_DOWN:
+            set_mouse_key_last_key_pos(1, record->event.key.col, record->event.key.row);
+            break;
+        case KC_MS_LEFT:
+            set_mouse_key_last_key_pos(2, record->event.key.col, record->event.key.row);
+            break;
+        case KC_MS_RIGHT:
+            set_mouse_key_last_key_pos(3, record->event.key.col, record->event.key.row);
+            break;
         default:
 #ifdef ANANLOG_MATRIX
             return process_record_profile( keycode, record);

--- a/keyboards/keychron/common/keychron_common.c
+++ b/keyboards/keychron/common/keychron_common.c
@@ -52,33 +52,33 @@ static key_combination_t key_comb_list[4] = {
 typedef struct {
     uint8_t col;
     uint8_t row;
+    uint16_t keycode;
 } key_pos_t;
 
-// An array for the 4 keys, all set to 255, 255 by default using key_post_t
-key_pos_t mouse_keys_pos[4] = {
-    {255, 255},
-    {255, 255},
-    {255, 255},
-    {255, 255},
+key_pos_t mouse_keys_pos[8] = {
+    {255, 255, KC_MS_UP},
+    {255, 255, KC_MS_DOWN},
+    {255, 255, KC_MS_LEFT},
+    {255, 255, KC_MS_RIGHT},
+    {255, 255, KC_MS_WH_UP},
+    {255, 255, KC_MS_WH_DOWN},
+    {255, 255, KC_MS_WH_LEFT},
+    {255, 255, KC_MS_WH_RIGHT},
 };
 
 void set_mouse_key_last_key_pos(uint8_t pos, uint8_t col, uint8_t row) {
-    if (pos>3) return;
+    if (pos>7) return;
     mouse_keys_pos[pos].col = col;
     mouse_keys_pos[pos].row = row;
 }
 
-inline bool is_mouse_key(uint8_t col, uint8_t row) {
-   for (uint8_t i = 0; i < 4; i++) {
+uint16_t is_mouse_key(uint8_t col, uint8_t row) {
+   for (uint8_t i = 0; i < 8; i++) {
         if (mouse_keys_pos[i].col == col && mouse_keys_pos[i].row == row) {
-            return true;
+            return mouse_keys_pos[i].keycode;
         }
     }
-    return false;
-}
-
-inline bool is_vertical_mouse_key(uint8_t col, uint8_t row) {
-    return (mouse_keys_pos[0].col == col && mouse_keys_pos[0].row == row) || (mouse_keys_pos[1].col == col && mouse_keys_pos[1].row == row);
+    return 0;
 }
 
 bool process_record_keychron_common(uint16_t keycode, keyrecord_t *record) {
@@ -144,6 +144,18 @@ bool process_record_keychron_common(uint16_t keycode, keyrecord_t *record) {
             break;
         case KC_MS_RIGHT:
             set_mouse_key_last_key_pos(3, record->event.key.col, record->event.key.row);
+            break;
+        case KC_MS_WH_UP:
+            set_mouse_key_last_key_pos(4, record->event.key.col, record->event.key.row);
+            break;
+        case KC_MS_WH_DOWN:
+            set_mouse_key_last_key_pos(5, record->event.key.col, record->event.key.row);
+            break;
+        case KC_MS_WH_LEFT:
+            set_mouse_key_last_key_pos(6, record->event.key.col, record->event.key.row);
+            break;
+        case KC_MS_WH_RIGHT:
+            set_mouse_key_last_key_pos(7, record->event.key.col, record->event.key.row);
             break;
         default:
 #ifdef ANANLOG_MATRIX

--- a/keyboards/keychron/common/keychron_common.h
+++ b/keyboards/keychron/common/keychron_common.h
@@ -42,6 +42,10 @@ enum {
     PROF1,
     PROF2,
     PROF3,
+    HE_M_UP,
+    HE_M_DOWN,
+    HE_M_LEFT,
+    HE_M_RIGHT,
 #endif
     NEW_SAFE_RANGE,
 };
@@ -57,6 +61,10 @@ enum {
     #define PROF1 KC_TRANS
     #define PROF2 KC_TRANS
     #define PROF3 KC_TRANS
+    #define HE_M_UP KC_TRANS
+    #define HE_M_DOWN KC_TRANS
+    #define HE_M_LEFT KC_TRANS
+    #define HE_M_RIGHT KC_TRANS
 #endif
 
 #define KC_TASK KC_TASK_VIEW
@@ -79,6 +87,11 @@ typedef struct PACKED {
 
 bool process_record_keychron_common(uint16_t keycode, keyrecord_t *record);
 void keychron_common_task(void);
+void set_mouse_vertical_last_key_pos(uint8_t col, uint8_t row);
+void set_mouse_horizontal_last_key_pos(uint8_t col, uint8_t row);
+void set_mouse_key_last_key_pos(uint8_t pos, uint8_t col, uint8_t row);
+bool is_mouse_key(uint8_t col, uint8_t row);
+bool is_vertical_mouse_key(uint8_t col, uint8_t row);
 
 #ifdef ENCODER_ENABLE
 void encoder_cb_init(void);

--- a/keyboards/keychron/common/keychron_common.h
+++ b/keyboards/keychron/common/keychron_common.h
@@ -90,8 +90,7 @@ void keychron_common_task(void);
 void set_mouse_vertical_last_key_pos(uint8_t col, uint8_t row);
 void set_mouse_horizontal_last_key_pos(uint8_t col, uint8_t row);
 void set_mouse_key_last_key_pos(uint8_t pos, uint8_t col, uint8_t row);
-bool is_mouse_key(uint8_t col, uint8_t row);
-bool is_vertical_mouse_key(uint8_t col, uint8_t row);
+uint16_t is_mouse_key(uint8_t col, uint8_t row);
 
 #ifdef ENCODER_ENABLE
 void encoder_cb_init(void);

--- a/keyboards/keychron/k2_he/ansi_rgb/config.h
+++ b/keyboards/keychron/k2_he/ansi_rgb/config.h
@@ -20,6 +20,7 @@
 /* RGB Matrix driver configuration */
 #    define DRIVER_COUNT 2
 #    define RGB_MATRIX_LED_COUNT 84
+#    define MOUSEKEY_VARIABLE 1
 
 #    define SPI_SCK_PIN A5
 #    define SPI_MISO_PIN A6

--- a/quantum/mousekey.h
+++ b/quantum/mousekey.h
@@ -120,6 +120,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #        define MOUSEKEY_WHEEL_DECELERATED_MOVEMENTS 8
 #    endif
 
+#ifndef MOUSEKEY_VARIABLE
+#    define MOUSEKEY_VARIABLE 0
+#endif
+
 #else /* #ifndef MK_3_SPEED */
 
 #    ifndef MK_C_OFFSET_UNMOD
@@ -190,6 +194,8 @@ void           mousekey_on(uint8_t code);
 void           mousekey_off(uint8_t code);
 void           mousekey_clear(void);
 void           mousekey_send(void);
+void           mousekey_set_speed_x(uint8_t);
+void           mousekey_set_speed_y(uint8_t);
 report_mouse_t mousekey_get_report(void);
 bool           should_mousekey_report_send(report_mouse_t *mouse_report);
 

--- a/quantum/mousekey.h
+++ b/quantum/mousekey.h
@@ -196,6 +196,8 @@ void           mousekey_clear(void);
 void           mousekey_send(void);
 void           mousekey_set_speed_x(uint8_t);
 void           mousekey_set_speed_y(uint8_t);
+void           mousekey_set_speed_h(uint8_t);
+void           mousekey_set_speed_v(uint8_t);
 report_mouse_t mousekey_get_report(void);
 bool           should_mousekey_report_send(report_mouse_t *mouse_report);
 


### PR DESCRIPTION
Add the support for Hall effect mouse keys (mouse speed depends on key travel).

## Description

You need to set MOUSEKEY_VARIABLE 1 in your keyboard config.h

Currently only tested on a Q2 HE.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
