### PR TITLE
Add proper guarding via the FACTORY_TEST_ENABLE def to allow proper user space enhancements

### DIFF
--- a/keyboards/keychron/common/factory_test.c
+++ b/keyboards/keychron/common/factory_test.c
@@ -462,7 +462,9 @@ void factory_test_rx(uint8_t *data, uint8_t length) {
     }
 }
 
+#ifdef FACTORY_TEST_ENABLE
 bool dip_switch_update_user(uint8_t index, bool active) {
+
     if (report_os_sw_state) {
 #ifdef INVERT_OS_SWITCH_STATE
         active = !active;
@@ -473,3 +475,4 @@ bool dip_switch_update_user(uint8_t index, bool active) {
 
     return true;
 }
+#endif

--- a/keyboards/keychron/k10_max/k10_max.c
+++ b/keyboards/keychron/k10_max/k10_max.c
@@ -91,6 +91,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/k10_pro_se2/k10_pro_se2.c
+++ b/keyboards/keychron/k10_pro_se2/k10_pro_se2.c
@@ -108,7 +108,11 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif
 #if 0

--- a/keyboards/keychron/k11_max/k11_max.c
+++ b/keyboards/keychron/k11_max/k11_max.c
@@ -77,6 +77,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/k13_max/k13_max.c
+++ b/keyboards/keychron/k13_max/k13_max.c
@@ -96,6 +96,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/k15_max/k15_max.c
+++ b/keyboards/keychron/k15_max/k15_max.c
@@ -55,16 +55,24 @@ void keyboard_post_init_kb(void) {
 }
 
 bool keychron_task_kb(void) {
+#ifdef FACTORY_TEST_ENABLE
     if (factory_reset_indicating()) {
         writePin(LED_CAPS_LOCK_PIN, !LED_PIN_ON_STATE);
-    } else {
-        if (host_keyboard_led_state().caps_lock) writePin(LED_CAPS_LOCK_PIN, LED_PIN_ON_STATE);
+    } else if (host_keyboard_led_state().caps_lock) {
+        writePin(LED_CAPS_LOCK_PIN, LED_PIN_ON_STATE);
     }
+#else
+    if (host_keyboard_led_state().caps_lock) writePin(LED_CAPS_LOCK_PIN, LED_PIN_ON_STATE);
+#endif
     return true;
 }
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/k17_max/k17_max.c
+++ b/keyboards/keychron/k17_max/k17_max.c
@@ -52,6 +52,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/k1_max/k1_max.c
+++ b/keyboards/keychron/k1_max/k1_max.c
@@ -91,6 +91,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/k2_max/k2_max.c
+++ b/keyboards/keychron/k2_max/k2_max.c
@@ -51,6 +51,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
    return !factory_reset_indicating();
+#else
+   return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/k3_max/k3_max.c
+++ b/keyboards/keychron/k3_max/k3_max.c
@@ -78,6 +78,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/k5_max/k5_max.c
+++ b/keyboards/keychron/k5_max/k5_max.c
@@ -95,6 +95,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/k7_max/k7_max.c
+++ b/keyboards/keychron/k7_max/k7_max.c
@@ -72,6 +72,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/k8_max/k8_max.c
+++ b/keyboards/keychron/k8_max/k8_max.c
@@ -89,6 +89,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/q0_max/q0_max.c
+++ b/keyboards/keychron/q0_max/q0_max.c
@@ -45,6 +45,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q10_max/q10_max.c
+++ b/keyboards/keychron/q10_max/q10_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q12_max/q12_max.c
+++ b/keyboards/keychron/q12_max/q12_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q13_max/q13_max.c
+++ b/keyboards/keychron/q13_max/q13_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q14_max/q14_max.c
+++ b/keyboards/keychron/q14_max/q14_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q15_max/q15_max.c
+++ b/keyboards/keychron/q15_max/q15_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q1_max/q1_max.c
+++ b/keyboards/keychron/q1_max/q1_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q2_max/q2_max.c
+++ b/keyboards/keychron/q2_max/q2_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q3_max/q3_max.c
+++ b/keyboards/keychron/q3_max/q3_max.c
@@ -78,6 +78,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/q5_max/q5_max.c
+++ b/keyboards/keychron/q5_max/q5_max.c
@@ -57,6 +57,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q60_max/q60_max.c
+++ b/keyboards/keychron/q60_max/q60_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q65_max/q65_max.c
+++ b/keyboards/keychron/q65_max/q65_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/q6_max/q6_max.c
+++ b/keyboards/keychron/q6_max/q6_max.c
@@ -79,6 +79,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/q8_max/q8_max.c
+++ b/keyboards/keychron/q8_max/q8_max.c
@@ -56,6 +56,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/v10_max/v10_max.c
+++ b/keyboards/keychron/v10_max/v10_max.c
@@ -79,6 +79,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/v1_max/v1_max.c
+++ b/keyboards/keychron/v1_max/v1_max.c
@@ -80,6 +80,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer_buffer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer_buffer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/v2_max/v2_max.c
+++ b/keyboards/keychron/v2_max/v2_max.c
@@ -79,6 +79,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/v3_max/v3_max.c
+++ b/keyboards/keychron/v3_max/v3_max.c
@@ -45,6 +45,10 @@ void keyboard_post_init_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return !factory_reset_indicating();
+#else
+    return true;
+#endif
 }
 #endif

--- a/keyboards/keychron/v4_max/v4_max.c
+++ b/keyboards/keychron/v4_max/v4_max.c
@@ -73,6 +73,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/v5_max/v5_max.c
+++ b/keyboards/keychron/v5_max/v5_max.c
@@ -79,6 +79,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/v6_max/v6_max.c
+++ b/keyboards/keychron/v6_max/v6_max.c
@@ -79,6 +79,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif

--- a/keyboards/keychron/v8_max/v8_max.c
+++ b/keyboards/keychron/v8_max/v8_max.c
@@ -78,6 +78,10 @@ bool keychron_task_kb(void) {
 
 #ifdef LK_WIRELESS_ENABLE
 bool lpm_is_kb_idle(void) {
+#ifdef FACTORY_TEST_ENABLE
     return power_on_indicator_timer == 0 && !factory_reset_indicating();
+#else
+    return power_on_indicator_timer == 0;
+#endif
 }
 #endif


### PR DESCRIPTION
## Description

Guard `factory_reset_indicating` and `dip_switch_update_user` with FACTORY_TEST_ENABLE conditional compilation flag.

In its current state, `factory_test.c` unconditionally defines `dip_switch_update_user`, preventing userspace configurations from overriding the Mac/Win DIP switch layer mapping. This goes against QMK coding practices as users are blocked from adding their own functionality.

Wrapping the existing code with `#ifdef FACTORY_TEST_ENABLE` allows users to #undef the define in their own keymap config.h and thus, they can provide their own implementation for this function, better following proper QMK code etiquette/style.

These changes also guard all `factory_reset_indicating()` calls across every board file (34 boards) which would fail to compile when `FACTORY_TEST_ENABLE` is undefined by a user, since `factory_test.h` includes are already conditionally guarded.

For default builds, these are no-op changes as `FACTORY_TEST_ENABLE` is currently always defined.  This only affects user builds where users explicitly undef FACTORY_TEST_ENABLE to be able to properly define their own dip_switch_update_user call.

Testing: No new tests are needed as the existing tests cover this code. Again, this should effectively be a no-op. This only affects custom user configurations where this value is explicitly undefined.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

n/a 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
