### PR TITLE
The saving of self-calibration data to the EEPROM has been disabled, …

### DIFF
--- a/keyboards/keychron/common/analog_matrix/analog_matrix.c
+++ b/keyboards/keychron/common/analog_matrix/analog_matrix.c
@@ -272,7 +272,7 @@ void analog_matrix_eeprom_update(const void *buf, void *addr, size_t len) {
     eeprom_update_block(buf, addr, len);
 }
 
-static void save_calibration_value(uint8_t row, uint8_t col) {
+/*static void save_calibration_value(uint8_t row, uint8_t col) {
     static uint8_t eeprom_calibrated;
 
     if (eeprom_calibrated != calibrated) {
@@ -288,7 +288,7 @@ static void save_calibration_value(uint8_t row, uint8_t col) {
 
     analog_matrix_eeprom_update(&calibrated, (void *)OFFSET_CALIBRATION, 1);
     analog_matrix_eeprom_update(&saved_calib_values[row][col], (void *)offset, sizeof(saved_calib_values[0][0]));
-}
+}*/
 
 static void save_calibration_values(void) {
     // Save to external EEPROM
@@ -545,7 +545,7 @@ void auto_caliration_check(uint8_t row, uint8_t col, uint16_t value) {
                         /* Save */
                         saved_calib_values[row][col].zero_travel = calib_values[row][col].zero_travel;
                         saved_calib_values[row][col].full_travel = calib_values[row][col].full_travel;
-                        save_calibration_value(row, col);
+                        //save_calibration_value(row, col);
                     } else {
                         calib_values[row][col].full_travel = p->value.full_travel - 15;
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The auto-calibration function ends up persistently writing data to the EEPROM, overwriting the data from the manual calibration done in Keychron Launcher. When manually calibrating in Keychron Launcher, the keys show a perfect travel between 0mm and 4mm, allowing customization of the actuation point to the desired millimeters (one of the advantages of using an HE keyboard). The problem is that with use, the auto-calibration replaces the manual calibration values, causing some keys to have a maximum travel of 1.8mm, others 3.0mm, etc., affecting typing and making it dependent on the auto-calibration in temporary RAM to "correct" this discrepancy.

I modified the firmware, preventing the `auto_calibration_check` function, which calls `save_calibration_value`, from persistently writing data. I'm using the modified firmware, and the keyboard doesn't show any problems since the manual calibration isn't affected. All the keys respond between 0mm and 4mm when turned on, and I can use any actuation point I want.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* With the modified firmware, the keyboard works perfectly and without errors. Ideally, the firmware should check for any existing manual calibration to avoid overwriting it.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
