### PR TITLE
Scale per-key V component by global V component rather than ignoring per-key V component

### DIFF
--- a/keyboards/keychron/common/rgb/per_key_rgb.c
+++ b/keyboards/keychron/common/rgb/per_key_rgb.c
@@ -32,7 +32,7 @@ bool per_key_rgb_solid(effect_params_t *params) {
 
     for (uint8_t i = led_min; i < led_max; i++) {
         hsv     = per_key_led[i];
-        hsv.v   = rgb_matrix_config.hsv.v;
+        hsv.v   = scale8(rgb_matrix_config.hsv.v, hsv.v);
         RGB rgb = hsv_to_rgb(hsv);
         rgb_matrix_region_set_color(params->region, i, rgb.r, rgb.g, rgb.b);
     }
@@ -46,7 +46,8 @@ bool per_key_rgb_breahting(effect_params_t *params) {
 
     for (uint8_t i = led_min; i < led_max; i++) {
         hsv     = per_key_led[i];
-        hsv.v   = scale8(abs8(sin8(time) - 128) * 2, rgb_matrix_config.hsv.v);
+        hsv.v   = scale8(rgb_matrix_config.hsv.v, hsv.v);
+        hsv.v   = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
         RGB rgb = hsv_to_rgb(hsv);
         RGB_MATRIX_TEST_LED_FLAGS();
         rgb_matrix_region_set_color(params->region, i, rgb.r, rgb.g, rgb.b);
@@ -74,10 +75,8 @@ bool per_key_rgb_reactive_simple(effect_params_t *params) {
         HSV      hsv    = per_key_led[i];
 
         if (offset > 255) offset = 255;
-        hsv.v = scale8(255 - offset, rgb_matrix_config.hsv.v);
-
-        // if (per_key_led[i].v < hsv.v)
-        //     hsv.v = per_key_led[i].v;
+        hsv.v = scale8(rgb_matrix_config.hsv.v, hsv.v);
+        hsv.v = scale8(255 - offset, hsv.v);
 
         RGB rgb = hsv_to_rgb(hsv);
         rgb_matrix_region_set_color(params->region, i, rgb.r, rgb.g, rgb.b);
@@ -104,9 +103,8 @@ bool per_key_rgb_effect_runner_reactive_splash(uint8_t start, effect_params_t *p
         }
         hsv.h = per_key_led[i].h;
         hsv.s = per_key_led[i].s;
-        hsv.v = scale8(hsv.v, rgb_matrix_config.hsv.v);
-        // if (per_key_led[i].v < hsv.v)
-        //    hsv.v = per_key_led[i].v;
+        hsv.v = scale8(rgb_matrix_config.hsv.v, per_key_led[i].v);
+
         RGB rgb = hsv_to_rgb(hsv);
         rgb_matrix_region_set_color(params->region, i, rgb.r, rgb.g, rgb.b);
     }


### PR DESCRIPTION
The per-key RGB (actually HSV) implementation currently completely ignores the per-key V component, meaning that every key must be the same brightness (V).  This means you cannot have any keys darker or lighter than others, only different hues and saturations.  This is not ideal for driving the keyboard's per-key RGB from external effects software such as OpenRGB or SignalRGB, which often generate effect patterns with varying brightness and expect the keyboard's LEDs to follow these colors accurately.

In this PR, I have updated the per-key RGB modes to scale the per-key V component by the global V component.  If the per-key V component is kept at 255 (full brightness) for each key, there is no functional change.  However, this now allows keys to have lower brightnesses than others, and they will scale accordingly.

Tested on Keychron Q2.  I can still adjust the brightness for the per-key modes using Fn+W/S but keys that are dimmer than full bright scale accordingly now.

Fixes https://github.com/Keychron/qmk_firmware/issues/480


Video of OpenRGB Effects Plugin with an effect that varies per-key brightness:

https://www.youtube.com/watch?v=vb103j4zNA8