### PR TITLE
Fix "Mix RGB" mode color leaking into single "Backlight" mode color

### DIFF
--- a/keyboards/keychron/common/rgb/mixed_rgb.c
+++ b/keyboards/keychron/common/rgb/mixed_rgb.c
@@ -65,6 +65,14 @@ void update_mixed_rgb_effect_count(void) {
 
 bool mixed_rgb(effect_params_t *params) {
     bool ret;
+    /* The per-zone effects below drive their colour through the *global*
+     * rgb_matrix_config via rgb_matrix_sethsv_noeeprom()/set_speed_noeeprom()
+     * while rendering. QMK never restores it afterwards, so the last zone's
+     * hue/sat/speed leaks into single-colour modes (e.g. Solid Color) once
+     * this effect is cycled away from. Snapshot the user's values here and
+     * restore them after the frame is composed. */
+    HSV     saved_hsv   = rgb_matrix_get_hsv();
+    uint8_t saved_speed = rgb_matrix_get_speed();
 
     extern uint8_t rgb_regions[RGB_MATRIX_LED_COUNT];
     if (params->init) {
@@ -78,6 +86,10 @@ bool mixed_rgb(effect_params_t *params) {
         params->region = i;
         ret            = multiple_rgb_effect_runner(params);
     }
+
+    /* Undo the global-state leak (rendering for this frame is already done). */
+    rgb_matrix_sethsv_noeeprom(saved_hsv.h, saved_hsv.s, saved_hsv.v);
+    rgb_matrix_set_speed_noeeprom(saved_speed);
 
     return ret;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Mixed RGB mode sets `rgb_matrix_config` during rendering but never reverts it to its original state from before / other effects. Proposed in this PR is that both hsv and speed values are saved before rendering mixed rgb mode and re-applied after it. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #493 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
