### PR TITLE
Add wireless battery reporting to Keychron raw HID

### DIFF
--- a/docs/features/rawhid.md
+++ b/docs/features/rawhid.md
@@ -12,6 +12,11 @@ Add the following to your `rules.mk`:
 RAW_ENABLE = yes
 ```
 
+Keychron wireless keyboards can route raw HID reports received over the wireless
+transport through the normal `raw_hid_receive()` handler by defining
+`WIRELESS_RAW_ENABLE`. Keychron's command `KC_GET_BATTERY_LEVEL` (`0xA4`)
+returns the cached battery percentage in byte 1 of the response.
+
 ## Basic Configuration {#basic-configuration}
 
 By default, the HID Usage Page and Usage ID for the Raw HID interface are `0xFF60` and `0x61`. However, they can be changed if necessary by adding the following to your `config.h`:

--- a/keyboards/keychron/common/keychron_raw_hid.c
+++ b/keyboards/keychron/common/keychron_raw_hid.c
@@ -33,6 +33,7 @@
 #    include "snap_click.h"
 #endif
 #if defined(LK_WIRELESS_ENABLE) || defined(KC_BLUETOOTH_ENABLE)
+#    include "battery.h"
 #    include "wireless.h"
 #    ifdef LK_WIRELESS_ENABLE
 #        include "lkbt51.h"
@@ -167,6 +168,12 @@ bool kc_raw_hid_rx(uint8_t src, uint8_t *data, uint8_t length) {
             data[1] = get_highest_layer(default_layer_state);
             data[2] = get_highest_layer(layer_state);
             break;
+
+#    if defined(LK_WIRELESS_ENABLE) || defined(KC_BLUETOOTH_ENABLE)
+        case KC_GET_BATTERY_LEVEL:
+            data[1] = battery_get_percentage();
+            break;
+#    endif
 
         case KC_MISC_CMD_GROUP:
             switch (data[1]) {

--- a/keyboards/keychron/common/keychron_raw_hid.h
+++ b/keyboards/keychron/common/keychron_raw_hid.h
@@ -25,6 +25,7 @@ enum {
     KC_GET_FIRMWARE_VERSION = 0xA1,
     KC_GET_SUPPORT_FEATURE  = 0xA2,
     KC_GET_DEFAULT_LAYER    = 0xA3,
+    KC_GET_BATTERY_LEVEL    = 0xA4,
     KC_MISC_CMD_GROUP       = 0xA7,
     KC_KEYCHRON_RGB         = 0xA8,
     KC_ANALOG_MATRIX        = 0xA9,

--- a/keyboards/keychron/common/wireless/wireless.c
+++ b/keyboards/keychron/common/wireless/wireless.c
@@ -606,13 +606,9 @@ void wireless_event_task(void) {
             case EVT_CONECTION_INTERVAL:
                 report_buffer_set_inverval(event.params.interval);
                 break;
-#if defined(RAW_ENABLE) && defined(WILRESS_RAW_ENABLE)
+#if defined(RAW_ENABLE) && defined(WIRELESS_RAW_ENABLE)
             case EVT_RAW_HID:
-#    ifdef VIA_ENABLE
-                via_raw_hid_receive(RAW_HID_SRC_WIRELESS, event.params.raw_hid_data, 32);
-#    else
-                kc_raw_hid_rx(RAW_HID_SRC_WIRELESS, event.params.raw_hid_data, 32);
-#    endif
+                raw_hid_receive(RAW_HID_SRC_WIRELESS, event.params.raw_hid_data, 32);
                 lpm_timer_reset();
                 break;
 #endif


### PR DESCRIPTION
## Description

This adds an opt-in wireless raw HID path to Keychron's common firmware and exposes the cached battery percentage to host utilities.

The change:

- Adds `KC_GET_BATTERY_LEVEL` (`0xA4`).
- Returns the battery percentage in response byte 1.
- Routes wireless `EVT_RAW_HID` events through the normal `raw_hid_receive()` handler.
- Corrects the misspelled `WILRESS_RAW_ENABLE` define to `WIRELESS_RAW_ENABLE`.
- Updates documentation accordingly to record the command and opt-in build define 
- Keeps wireless transport routing disabled unless a keyboard explicitly defines `WIRELESS_RAW_ENABLE`.

This allows a Keychron 2.4 GHz receiver to report keyboard battery status without using Bluetooth. It does not modify receiver firmware, battery calculation, key behavior, or Bluetooth behavior.

## Types of Changes

- [x] Core
- [x] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Verification

- `git diff --check` passes.
- The change is based on Keychron's `2025q3` branch.
- The combined common-core and K8 HE opt-in firmware was built successfully.
- The resulting firmware was tested on a Keychron K8 HE using the Keychron 2.4 GHz receiver.
- A tray utility successfully retrieved a valid battery percentage over 2.4 GHz.
- Keyboard worked fine with no issues over wired connection, 2.4 GHz, and Bluetooth. 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).