### PR TITLE
Enable wireless raw HID for the Keychron K8 HE

### DIFF
--- a/keyboards/keychron/k8_he/rules.mk
+++ b/keyboards/keychron/k8_he/rules.mk
@@ -7,6 +7,7 @@ USE_FPU = yes
 
 OPT_DEFS += -DSHARED_EP_ENABLE -DKEYBOARD_SHARED_EP
 OPT_DEFS += -DXINPUT_ENABLE
+OPT_DEFS += -DWIRELESS_RAW_ENABLE
 
 include keyboards/keychron/common/analog_matrix/analog_matrix.mk
 include keyboards/keychron/common/keychron_common.mk


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Enable `WIRELESS_RAW_ENABLE` for the Keychron K8 HE so its 2.4 GHz wireless transport can forward raw HID battery requests through the common Keychron firmware handler.

This applies to the ANSI, ISO, and JIS K8 HE targets through the shared keyboard rules.

This is the keyboard-specific follow-up to #504. It doesn't affect keymaps, layouts, receiver firmware, battery calculation, or Bluetooth behavior.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Depends on #504, which provides the common wireless raw HID implementation.

## Verification

- `git diff --check` passes.
- ANSI, ISO, and JIS K8 HE firmware targets build successfully from QMK MSYS
- The combined core and K8 HE changes were tested on a Keychron K8 HE using the Keychron 2.4 GHz receiver.
- A tray utility successfully retrieved a valid battery percentage over 2.4 GHz.
- Keyboard continues to function normally over wired connection, 2.4 GHz, and Bluetooth

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [X] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
