### PR TITLE
[K1 Pro] Provide weak `raw_hid_receive_kb` function

### DIFF
--- a/keyboards/keychron/k1_pro/k1_pro.c
+++ b/keyboards/keychron/k1_pro/k1_pro.c
@@ -289,6 +289,18 @@ void battery_calculte_voltage(uint16_t value) {
     battery_set_voltage(voltage);
 }
 
+/**
+ * Default no-op: only exists so via_command_kb()'s default case below has
+ * something to call regardless of which keymap is being built. A keymap
+ * that wants to handle raw HID command IDs this board doesn't already
+ * claim (0xAA/0xAB above) can define its own strong raw_hid_receive_kb()
+ * to override this weak one — same override convention QMK itself uses
+ * for via_command_kb().
+ */
+__attribute__((weak)) bool raw_hid_receive_kb(uint8_t *data, uint8_t length) {
+    return false;
+}
+
 bool via_command_kb(uint8_t *data, uint8_t length) {
     switch (data[0]) {
 #ifdef KC_BLUETOOTH_ENABLE
@@ -302,7 +314,7 @@ bool via_command_kb(uint8_t *data, uint8_t length) {
             break;
 #endif
         default:
-            return false;
+            return raw_hid_receive_kb(data, length);
     }
 
     return true;


### PR DESCRIPTION
Added a default weak implementation for `raw_hid_receive_kb` to allow handling of raw HID commands.

## Description

This enables the K1 Pro to support custom HID IDs added by custom firmware without first having to patch this codebase (to add this change).

I am adding this to support adding AI-status keys (that function bidirectionally) to the K1 Pro, which I have already added to an unrelated QMK keyboard.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
    - Changes an inline `false` to one that can be overridden