### PR TITLE
Keep earlier splashes rendering when a new key is pressed

### DIFF
--- a/keyboards/keychron/common/rgb/per_key_rgb.c
+++ b/keyboards/keychron/common/rgb/per_key_rgb.c
@@ -136,7 +136,9 @@ static HSV SPLASH_math(HSV hsv, int16_t dx, int16_t dy, uint8_t dist, uint16_t t
 }
 
 bool per_key_rgb_reactive_splash(effect_params_t *params) {
-    return per_key_rgb_effect_runner_reactive_splash(qsub8(g_last_hit_tracker.count, 1), params, &SPLASH_math);
+    // Start from 0 so every remembered hit keeps rendering: a new keypress adds
+    // a splash instead of replacing the one still fading out.
+    return per_key_rgb_effect_runner_reactive_splash(0, params, &SPLASH_math);
 }
 
 bool per_key_rgb(effect_params_t *params) {

--- a/keyboards/keychron/k10_he/info.json
+++ b/keyboards/keychron/k10_he/info.json
@@ -49,14 +49,14 @@
             "digital_rain": true,
             "dual_beacon": true,
             "jellybean_raindrops": true,
+            "multisplash": true,
             "pixel_rain": true,
             "rainbow_beacon": true,
             "rainbow_moving_chevron": true,
+            "solid_multisplash": true,
             "solid_reactive_multinexus": true,
             "solid_reactive_multiwide": true,
             "solid_reactive_simple": true,
-            "solid_splash": true,
-            "splash": true,
             "typing_heatmap": true
         }
     },


### PR DESCRIPTION
## Description

`SPLASH` and `SOLID_SPLASH` render only the most recent key hit, because they start the shared runner at `count - 1`:

```c
return effect_runner_reactive_splash(qsub8(g_last_hit_tracker.count, 1), params, &SPLASH_math);
```

Pressing a second key while the first splash is still fading makes that first splash disappear in a single frame, which reads as a glitch rather than as an effect.

QMK already ships multi-hit variants of the same two effects, `MULTISPLASH` and `SOLID_MULTISPLASH`. They use the same math and the same runner, started at `0`, so every remembered hit keeps rendering until it fades out on its own. This PR enables those on the K10 HE, and makes the equivalent change to the Keychron per-key splash, where no multi-hit variant exists.

The two changes are in separate commits so either can be taken on its own.

### Effect indices do not move

This matters because the effect list is pinned on the Launcher side. In `splash_anim.h` and `solid_splash_anim.h` the single-hit and multi-hit effects are declared consecutively, each behind its own `#ifdef`, so disabling one and enabling the other registers exactly one entry in the same enum slot.

Confirmed on a local build with temporary `_Static_assert`s over the whole list: `Splash` stays 21, `Solid Splash` stays 22, `PER_KEY_RGB` stays 23, `MIXED_RGB` stays 24, `RGB_MATRIX_EFFECT_MAX` stays 25.

### Consistency with the rest of the board

The K10 HE already enables `solid_reactive_multiwide` and `solid_reactive_multinexus` — the multi-hit variants of their families — while splash was left single-hit. Likewise, in `per_key_rgb.c`, `per_key_rgb_reactive_multi_wide()` already passes `0`, while `per_key_rgb_reactive_splash()` passed `count - 1`.

### Cost

No new state: the hit tracker is the same fixed 41-byte `last_hit_t`, still capped at `LED_HITS_TO_REMEMBER`. Comparing ELF sections before and after, `.data` and `.bss` are byte-identical and `.text` is 40 bytes smaller. Per render task the inner loop can now run up to `LED_HITS_TO_REMEMBER` times per LED, but `RGB_MATRIX_LED_PROCESS_LIMIT` is 21 of 104 LEDs, and the same runner already runs this way for the two reactive effects above.

The visible trade-off is that during sustained fast typing more splashes overlap, so more of the matrix is lit. Simulating the runner on the host over 3 s of typing at roughly 8 keys/s, mean matrix brightness goes from 32/255 to 235/255. If that is not wanted at the board level, the first commit can be dropped and the second taken on its own.

### Verification

- Builds clean for `keychron/k10_he/ansi:keychron` with no new warnings.
- Effect indices checked with static assertions as described above.
- The runner and the effect math were compiled on the host against the real `effect_runner_reactive_splash.h` and `solid_splash_anim.h`, driven by a copy of the hit-tracking and ageing logic from `rgb_matrix.c`, to compare both variants under identical input: brightness at the first key drops to 0 on the next keypress with the single-hit variant and continues its fade with the multi-hit one. Both variants go fully dark after typing stops (928 ms), and 10 000 consecutive hits never push the tracker past `LED_HITS_TO_REMEMBER`.
- Not yet flashed to hardware.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage). See Verification above; hardware flashing is still pending.
